### PR TITLE
Added show method for genambig, Genotypes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Title: Tools for Polyploid Microsatellite Analysis
 Authors@R: c(person("Lindsay V.", "Clark", email = "lvclark@illinois.edu", role = c("aut", "cre"),
                     comment = c(ORCID = "0000-0002-3881-9252")),
              person("Handunnethi Nihal", "de Silva", role = "ctb"))
-Author: Lindsay V. Clark [aut, cre], Handunnethi Nihal de Silva [ctb]
+Author: Lindsay V. Clark [aut, cre], Handunnethi Nihal de Silva [ctb], Tyler William Smith [ctb]
 Maintainer: Lindsay V. Clark <lvclark@illinois.edu>
 Imports: methods, stats, utils, grDevices, graphics, Rcpp
 Suggests: ade4, adegenet, ape

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -22,7 +22,7 @@ exportMethods(estimatePloidy, Samples, "Samples<-", Loci, "Loci<-", PopInfo,
               Description, "Description<-", PopNum, "PopNum<-", Genotype,
               "Genotype<-", Genotypes, "Genotypes<-", isMissing, viewGenotypes,
               editGenotypes, Present, "Present<-", Absent, "Absent<-", summary,
-              merge, pld, "pld<-", plCollapse, genIndex)
+              merge, pld, "pld<-", plCollapse, genIndex, show)
 exportClasses(gendata, genambig, genbinary, ploidysuper, ploidymatrix, 
               ploidylocus, ploidysample, ploidyone)
 import(methods)

--- a/R/classes_generics_methods.R
+++ b/R/classes_generics_methods.R
@@ -1086,38 +1086,43 @@ setMethod("isMissing", "genambig", function(object, samples, loci){
 setMethod(
   f = "show",
   signature = "genambig",
-  def <- function(object){
+  function(object){
     cat(Description(object), "\n")
     cat("Missing values: ", (Missing(object)), "\n")
     cat("\nGenotypes: \n")
     genSum <- apply(object@Genotypes, 2,
                     function(x)
-                      unlist(lapply(x, function(y) paste(y, collapse = "/"))))
-    print(genSum)
+                      unlist(lapply(x, function(y)
+                        paste(sort(y), collapse = "/"))))
+    print(genSum, quote = FALSE)
 
     cat("\nSSR motif lengths: \n")
-    if(all(is.na(Usatnts(object))))
+    if(all(is.na(Usatnts(object)))){
       cat(" none\n")
-    else
+    } else {
       print(Usatnts(object))
+    }
 
     cat("\nPloidies: \n")
-    if(all(is.na(Ploidies(object))))
+    if(all(is.na(Ploidies(object)))){
       cat(" none\n")
-    else
+    } else {
       print(Ploidies(object))
+    }
 
     cat("\nPopNames: \n")
-    if(length(PopNames(object)) > 0)
+    if(length(PopNames(object)) > 0){
       print(PopNames(object))
-    else
+    } else {
       cat(" none\n")
+    }
 
     cat("\nPopInfo: \n")
-    if(all(is.na(PopInfo(object))))
+    if(all(is.na(PopInfo(object)))){
       cat(" none\n")
-    else
+    } else {
       print(PopInfo(object))
+    }
   }
 )
 

--- a/R/classes_generics_methods.R
+++ b/R/classes_generics_methods.R
@@ -1050,7 +1050,9 @@ setReplaceMethod("Genotype", "genambig", function(object, sample, locus, value){
 setMethod("Genotypes", signature(object = "genambig", samples = "ANY",
                                  loci = "ANY"),
           function(object, samples, loci){
-              return(object@Genotypes[samples, loci, drop=FALSE])
+            apply(object@Genotypes[samples, loci, drop = FALSE], 2,
+                  function(x)
+                    unlist(lapply(x, function(y) paste(y, collapse = "/"))))
           })
 setReplaceMethod("Genotypes", "genambig",
                  function(object, samples,
@@ -1082,6 +1084,41 @@ setMethod("isMissing", "genambig", function(object, samples, loci){
         return(result)
     }
 })
+
+setMethod(
+  f = "show",
+  signature = "genambig",
+  def <- function(object){
+    cat(Description(object), "\n")
+    cat("Missing values: ", (Missing(object)), "\n")
+    cat("\nGenotypes: \n")
+    print(Genotypes(object))
+
+    cat("\nSSR motif lengths: \n")
+    if(all(is.na(Usatnts(object))))
+      cat(" none\n")
+    else
+      print(Usatnts(object))
+
+    cat("\nPloidies: \n")
+    if(all(is.na(Ploidies(object))))
+      cat(" none\n")
+    else
+      print(Ploidies(object))
+
+    cat("\nPopNames: \n")
+    if(length(PopNames(object)) > 0)
+      print(PopNames(object))
+    else
+      cat(" none\n")
+
+    cat("\nPopInfo: \n")
+    if(all(is.na(PopInfo(object))))
+      cat(" none\n")
+    else
+      print(PopInfo(object))
+  }
+)
 
 # summary method for genambig
 setMethod("summary", "genambig", function(object){

--- a/R/classes_generics_methods.R
+++ b/R/classes_generics_methods.R
@@ -1050,9 +1050,7 @@ setReplaceMethod("Genotype", "genambig", function(object, sample, locus, value){
 setMethod("Genotypes", signature(object = "genambig", samples = "ANY",
                                  loci = "ANY"),
           function(object, samples, loci){
-            apply(object@Genotypes[samples, loci, drop = FALSE], 2,
-                  function(x)
-                    unlist(lapply(x, function(y) paste(y, collapse = "/"))))
+            return(object@Genotypes[samples, loci, drop=FALSE])
           })
 setReplaceMethod("Genotypes", "genambig",
                  function(object, samples,
@@ -1092,7 +1090,10 @@ setMethod(
     cat(Description(object), "\n")
     cat("Missing values: ", (Missing(object)), "\n")
     cat("\nGenotypes: \n")
-    print(Genotypes(object))
+    genSum <- apply(object@Genotypes, 2,
+                    function(x)
+                      unlist(lapply(x, function(y) paste(y, collapse = "/"))))
+    print(genSum)
 
     cat("\nSSR motif lengths: \n")
     if(all(is.na(Usatnts(object))))

--- a/man/genambig-class.Rd
+++ b/man/genambig-class.Rd
@@ -16,6 +16,7 @@
 \alias{Missing<-,genambig-method}
 \alias{Samples<-,genambig-method}
 \alias{summary,genambig-method}
+\alias{show,genambig-method}
 \alias{viewGenotypes,genambig-method}
 \alias{[,genambig-method}
 
@@ -139,6 +140,12 @@ Boolean value or an array of Boolean values is returned.}
       dataset description (\code{Description} slot) to the console as
       well as the number of missing genotypes, then calls the
       \code{summary} method for \code{gendata}. }
+    \item{show}{\code{signature(object = "genambig")}: Prints the
+      data to the console, formatted to make it more legible. The
+      genotype for each locus is shown as the size of each allele,
+      separated by a '/'. The SSR motif length ('Usatnts'), Ploidies,
+      Population Names, and Population membership ('PopInfo') are
+      displayed if they exist.}
     \item{viewGenotypes}{\code{signature(object = "genambig")}: Prints a
     tab-delimited table of samples, loci, and genotype vectors to the console.}
     \item{"["}{\code{signature(x = "genambig", i = "ANY", j = "ANY")}:


### PR DESCRIPTION
Hi Dr. Clark,

Thanks for sharing polysat, it's great! I hope it's not too forward, I've made a few suggestions to enhance interactive viewing of genambig objects at the command prompt. I'm happy to make changes to this, or you can ignore it completely, as you like. 

The original version of Genotypes produced an awkwardly formatted matrix,
with heterozygous loci reported as 'integer(3)'. I modified the method so
that it actually shows a character representation of the genotype (e.g., "240/246/252"). It would be easy to modify this to just show the number of alleles (i.e., '3'), or any other useful summary of the genotype.

Here's what the output looks like with my change:

```
> Genotypes(simgen)
     loc1              loc2              loc3             
A1   "110/112/106"     "164/155/161"     "218/214/216/222"
A2   "114/106/118/110" "158/161"         "222/218/230"    
A3   "114/102/100/106" "158/161/155/152" "230/210/218"    
A4   "110/102/106/100" "161/155/158"     "214/218/216/230"
A5   "106/112"         "155/152"         "214/218"        
```

I also added a `show` method for class genambig. This adds a bit of
formatting to the display to make it a little easier to parse when viewed
at the console.

Here's the output, with the Genotypes matrix truncated for space:

```
> simgen
Insert dataset description here. 
Missing values:  -9 

Genotypes: 
     loc1              loc2              loc3             
A1   "110/112/106"     "164/155/161"     "218/214/216/222"
A2   "114/106/118/110" "158/161"         "222/218/230"    
A3   "114/102/100/106" "158/161/155/152" "230/210/218"    
A4   "110/102/106/100" "161/155/158"     "214/218/216/230"
A5   "106/112"         "155/152"         "214/218"        
...    ...                      ...                     ...
C98  "116/112"         "143/155"         "226/220"        
C99  "114/116/104"     "146/155/152"     "220/210/212"    
C100 "108/116/104/100" "149/164/155/146" "226/222/210"    

SSR motif lengths: 
 none

Ploidies: 
 none

PopNames: 
 none

PopInfo: 
 none
```

Neither of these changes alters the data at all, just the display when working interactively at the command prompt. We're just starting to use polysat in our lab, so this may break something I'm not aware of.