### PR TITLE
clean-up structure export

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,10 @@ Date: 2018-05-28
 Title: Tools for Polyploid Microsatellite Analysis
 Authors@R: c(person("Lindsay V.", "Clark", email = "lvclark@illinois.edu", role = c("aut", "cre"),
                     comment = c(ORCID = "0000-0002-3881-9252")),
-             person("Handunnethi Nihal", "de Silva", role = "ctb"))
+             person("Handunnethi Nihal", "de Silva", role = "ctb"),
+             person(given = "Tyler", middle = "William", family = "Smith",
+                    email = "tyler@plantarum.ca", role = "ctb",
+                    comment = c(ORCID = "0000-0001-7683-2653")))
 Author: Lindsay V. Clark [aut, cre], Handunnethi Nihal de Silva [ctb], Tyler William Smith [ctb]
 Maintainer: Lindsay V. Clark <lvclark@illinois.edu>
 Imports: methods, stats, utils, grDevices, graphics, Rcpp

--- a/R/dataexport.R
+++ b/R/dataexport.R
@@ -87,8 +87,13 @@ write.Structure <- function(object, ploidy, file="",
         structdata[[thiscol]]<-alleles
         names(structdata)[thiscol]<-L
     }
-   write.table(structdata, file=file, sep="\t", row.names=FALSE,
-               quote=FALSE, col.names=TRUE)
+    write.table(structdata, file=file, sep="\t", row.names=FALSE,
+                quote=FALSE, col.names=TRUE)
+    tmpFile <- readLines(file)
+    tmpFile[1] <- gsub("rowlabel\t", "", tmpFile[1])
+    tmpFile[1] <- gsub("PopInfo\t", "", tmpFile[1])
+    tmpFile[2] <- gsub("missing\t", "", tmpFile[2])
+    writeLines(text = tmpFile, con = file)
 }
 
 write.GenoDive<-function(object,


### PR DESCRIPTION
Hi Lindsay,

As you know, write.structure leaves a couple of column headers in the output file that the user needs to remove 'by-hand'. I added a few lines of code that do this automatically, at least for the case when no extra columns are added. If it looks sensible, it wouldn't take much more effort to test it out more thoroughly to make sure it doesn't cause new problems. Let me know what you think.

Best,

Tyler